### PR TITLE
Gotham font update

### DIFF
--- a/src/components/CustomStyles.astro
+++ b/src/components/CustomStyles.astro
@@ -7,9 +7,9 @@
   :root {
     /* WARNING: These Font Variables are not used. These values are hardcoded in the tailwind.config.cjs
     to make reusing tailwind without Astro easier. Please change the value in that file */
-    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B",Arial, Helvetica, sans-serif';
     --aw-font-serif: 'Georgia';
-    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B",Arial, Helvetica, sans-serif';
 
     --aw-color-primary: rgb(77, 25, 121);
     --aw-color-primary-dark: rgb(46, 26, 71);
@@ -18,7 +18,7 @@
     --aw-color-highlight: rgb(255, 235, 59);
     --aw-color-highlight-muted: rgb(255, 249, 196);
 
-    --aw-color-text-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-color-text-heading: '"Gotham SSm A", "Gotham SSm B",Arial, Helvetica, sans-serif';
     --aw-color-text-default: rgb(16 16 16);
     --aw-color-text-muted: rgb(16 16 16 / 66%);
     --aw-color-bg-page: rgb(255 255 255);
@@ -31,9 +31,9 @@
   }
 
   .dark {
-    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B",Arial, Helvetica, sans-serif';
     --aw-font-serif: 'Georgia';
-    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B",Arial, Helvetica, sans-serif';
 
     --aw-color-primary: rgb(1 97 239);
     --aw-color-secondary: rgb(1 84 207);

--- a/src/components/CustomStyles.astro
+++ b/src/components/CustomStyles.astro
@@ -1,29 +1,15 @@
 ---
-import '@fontsource-variable/inter';
-
-// 'DM Sans'
-// Nunito
-// Dosis
-// Outfit
-// Roboto
-// Literata
-// 'IBM Plex Sans'
-// Karla
-// Poppins
-// 'Fira Sans'
-// 'Libre Franklin'
-// Inconsolata
-// Raleway
-// Oswald
-// 'Space Grotesk'
-// Urbanist
+// If needed you can use fontsource to load fonts, but Gotham cannot be loaded this way as
+// we license it through a different method. You can use this to load other fonts.
 ---
 
 <style is:inline>
   :root {
-    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B", Arial, Helvetica, sans-serif;';
-    --aw-font-serif: 'InterVariable';
-    --aw-font-heading: 'InterVariable';
+    /* WARNING: These Font Variables are not used. These values are hardcoded in the tailwind.config.cjs
+    to make reusing tailwind without Astro easier. Please change the value in that file */
+    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-serif: 'Georgia';
+    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
 
     --aw-color-primary: rgb(77, 25, 121);
     --aw-color-primary-dark: rgb(46, 26, 71);
@@ -32,7 +18,7 @@ import '@fontsource-variable/inter';
     --aw-color-highlight: rgb(255, 235, 59);
     --aw-color-highlight-muted: rgb(255, 249, 196);
 
-    --aw-color-text-heading: 'InterVariable';
+    --aw-color-text-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
     --aw-color-text-default: rgb(16 16 16);
     --aw-color-text-muted: rgb(16 16 16 / 66%);
     --aw-color-bg-page: rgb(255 255 255);
@@ -45,9 +31,9 @@ import '@fontsource-variable/inter';
   }
 
   .dark {
-    --aw-font-sans: 'InterVariable';
-    --aw-font-serif: 'InterVariable';
-    --aw-font-heading: 'InterVariable';
+    --aw-font-sans: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
+    --aw-font-serif: 'Georgia';
+    --aw-font-heading: '"Gotham SSm A", "Gotham SSm B","Open Sans"';
 
     --aw-color-primary: rgb(1 97 239);
     --aw-color-secondary: rgb(1 84 207);

--- a/src/components/common/CommonMeta.astro
+++ b/src/components/common/CommonMeta.astro
@@ -6,3 +6,4 @@ import { getAsset } from '~/utils/permalinks';
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <link rel="sitemap" href={getAsset('/sitemap-index.xml')} />
+<link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7451856/7076412/css/fonts.css" />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -16,9 +16,9 @@ module.exports = {
         muted: 'var(--aw-color-text-muted)',
       },
       fontFamily: {
-        sans: ['var(--aw-font-sans, ui-sans-serif)', ...defaultTheme.fontFamily.sans],
-        serif: ['var(--aw-font-serif, ui-serif)', ...defaultTheme.fontFamily.serif],
-        heading: ['var(--aw-font-heading, ui-sans-serif)', ...defaultTheme.fontFamily.sans],
+        sans: ['"Gotham SSm A", "Gotham SSm B","Open Sans"', ...defaultTheme.fontFamily.sans],
+        serif: ['Georgia', ...defaultTheme.fontFamily.serif],
+        heading: ['"Gotham SSm A", "Gotham SSm B","Open Sans"', ...defaultTheme.fontFamily.sans],
       },
     },
   },

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -16,9 +16,9 @@ module.exports = {
         muted: 'var(--aw-color-text-muted)',
       },
       fontFamily: {
-        sans: ['"Gotham SSm A", "Gotham SSm B","Open Sans"', ...defaultTheme.fontFamily.sans],
+        sans: '"Gotham SSm A", "Gotham SSm B", Arial, Helvetica, sans-serif',
         serif: ['Georgia', ...defaultTheme.fontFamily.serif],
-        heading: ['"Gotham SSm A", "Gotham SSm B","Open Sans"', ...defaultTheme.fontFamily.sans],
+        heading: '"Gotham SSm A", "Gotham SSm B", Arial, Helvetica, sans-serif',
       },
     },
   },


### PR DESCRIPTION
This is good to go. Ed activated the font to be used on localhost. 

Since we want to reuse tailwind, I hard coded the font in the tailwind.config file. I did also set the CustomStyles.Astro variables to Gotham incase the variable gets used in some future time. I put a note in that file to change it in the tailwind config

Also changed the Serif Font from Inter to Georgia so we don't have to import Inter and use the fontsource plugin.