### PR TITLE
Search results page styling

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -61,17 +61,22 @@ const { items, query, correctedQuery } = results;
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
+  .search-results :global(b) {
+    color: purple;
+  }
 </style>
 <Layout metadata={{ title }}>
   <Header />
-  <section class="max-w-5xl mx-auto px-8 w-full">
+  <section class="max-w-5xl mx-auto px-8 w-full search-results">
     <p class="text-[11px] pt-4 uppercase">
-      <a class="mr-3" href="~/">Home</a> / <span class="ml-3">Search Results</span>
+      <a class="mr-3" href="~/">Home</a>
+      <span class="text-slate-400">/</span>
+      <span class="ml-3">Search Results</span>
     </p>
     <h1 class="text-3xl font-bold uppercase py-8" ">Search Results</h1>
     {
       results?.correctedQuery && (
-        <div>
+        <div class="py-4">
           No results found for <span class="bold">"{results?.query}"</span>. Showing results for{' '}
           <span class="bold">"{correctedQuery}"</span> instead.
         </div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -54,31 +54,44 @@ const { items, query, correctedQuery } = results;
 // }
 ---
 
+<style>
+  h1 {
+    border-bottom: 2px solid rgba(77, 25, 121, 0.35);
+    padding-bottom: 0.5rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+</style>
 <Layout metadata={{ title }}>
   <Header />
-  <h1>Search Results</h1>
-  {
-    results?.correctedQuery && (
-      <div>
-        No results found for <span class="bold">"{results?.query}"</span>. Showing results for{' '}
-        <span class="bold">"{correctedQuery}"</span> instead.
-      </div>
-    )
-  }
-  {
-    items &&
-      items.map((item) => (
-        <div class="py-4">
-          <h2>
-            <a href={item.link}>{item.title}</a>
-          </h2>
-          <span set:html={item.htmlSnippet} />
+  <section class="max-w-5xl mx-auto px-8 w-full">
+    <p class="text-[11px] pt-4 uppercase">
+      <a class="mr-3" href="~/">Home</a> / <span class="ml-3">Search Results</span>
+    </p>
+    <h1 class="text-3xl font-bold uppercase py-8" ">Search Results</h1>
+    {
+      results?.correctedQuery && (
+        <div>
+          No results found for <span class="bold">"{results?.query}"</span>. Showing results for{' '}
+          <span class="bold">"{correctedQuery}"</span> instead.
         </div>
-      ))
-  }
+      )
+    }
+    {
+      items &&
+        items.map((item) => (
+          <div class="py-4">
+            <h2 class="underline">
+              <a href={item.link}>{item.title}</a>
+            </h2>
+            <span set:html={item.htmlSnippet} />
+          </div>
+        ))
+    }
+  </section>
   <Footer />
 </Layout>
-<!-- 
+<!--
 export default SearchPage
 
 const SearchResult = styled.div`


### PR DESCRIPTION
This is good to go, it does need the template-page-main-function styling to make the spacing work but it should be good after that.

One note, breadcrumbs are normally based on the page-content from the API, in this case that data does not exist so I just hardcoded the breadcrumbs into the page.