### PR TITLE
Events page styling

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -137,10 +137,9 @@ h2 {
   list-style-position: outside;
   margin-inline-start: 20px;
 }
-section ul{
-  margin-left:1.5rem;
+section ul {
+  margin-left: 1.5rem;
   list-style-position: outside;
-
 }
 .callout h3 {
   margin-top: 0;
@@ -160,7 +159,6 @@ section ul{
   margin: 0 0 1rem 0;
   padding: 0.85em 1em;
   border: 1px solid transparent;
-  border-radius: 0;
   transition:
     background-color 0.25s ease-out,
     color 0.25s ease-out;
@@ -195,13 +193,13 @@ tbody td {
 body main li {
   margin-bottom: 0.6rem;
 }
-section ul{
-  margin-left:1.5rem;
+section ul {
+  margin-left: 1.5rem;
   list-style-position: outside;
   list-style-type: disc;
 }
-section ol{
-  margin-left:1.5rem;
+section ol {
+  margin-left: 1.5rem;
   list-style-position: outside;
   list-style-type: decimal;
 }
@@ -212,10 +210,10 @@ table {
   margin-bottom: 1rem;
   border-radius: 0;
 }
-.accordion dd p:first-of-type{
+.accordion dd p:first-of-type {
   padding: 0rem;
 }
-.accordion dd img{
+.accordion dd img {
   margin-right: 1.3rem;
   margin-top: 0rem;
   margin-bottom: 1.5rem;
@@ -239,4 +237,10 @@ button.tag {
   /* &:hover {
     background: ${(props) => (props.active ? '#4e79a6' : '#efefef')};
   } */
+}
+h1.acc-bottom-border-line {
+  border-bottom: 2px solid rgba(77, 25, 121, 0.35);
+  padding-bottom: 0.5rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -223,20 +223,29 @@ table {
   margin-top: 0;
 }
 
-button.tag {
+.tag {
   display: inline-block;
-  padding: 6px;
+  padding: 2px 6px;
   margin: 4px;
   /* background: ${(props) => (props.active ? 'rgb(40, 62, 85)' : 'rgb(193, 196, 197)')};
   color: ${(props) => (props.active ? 'white' : '#424242')}; */
   border-radius: 4px;
   font-size: 0.8em;
   cursor: pointer;
+  border-radius: 0.25rem;
+  background-color: rgb(203, 206, 207);
   transition: background 0.25s ease-out;
 
   /* &:hover {
     background: ${(props) => (props.active ? '#4e79a6' : '#efefef')};
   } */
+}
+.tag:hover {
+  background-color: rgb(239, 239, 239);
+}
+.tag.active {
+  background: rgb(40, 62, 85);
+  color: white;
 }
 h1.acc-bottom-border-line {
   border-bottom: 2px solid rgba(77, 25, 121, 0.35);

--- a/src/components/widgets/Calendar/CalendarGrid.jsx
+++ b/src/components/widgets/Calendar/CalendarGrid.jsx
@@ -71,7 +71,7 @@ export default function CalendarGrid({ calendarData }) {
   return (
     <div>
       {tags.length > 0 && (
-        <div className="mt-6 mb-2.5">
+        <div className="mt-6 mb-8">
           <p>Click on the tags below to filter the workshops by topic:</p>
           {tags.map((tag, i) => (
             <button
@@ -86,7 +86,7 @@ export default function CalendarGrid({ calendarData }) {
         </div>
       )}
 
-      <div className="flex flex-wrap justify-around -mx-4">
+      <div className="flex flex-wrap justify-around gap-4">
         {activeEvents.length > 0
           ? activeEvents.map((event, i) => <Event event={event} key={i} />)
           : events.map((event, i) => <Event event={event} key={i} />)}

--- a/src/components/widgets/Calendar/CalendarGrid.jsx
+++ b/src/components/widgets/Calendar/CalendarGrid.jsx
@@ -75,7 +75,7 @@ export default function CalendarGrid({ calendarData }) {
           <p>Click on the tags below to filter the workshops by topic:</p>
           {tags.map((tag, i) => (
             <button
-              className="inline-block text-sm active:bg-slate-200 mx-1 bg-slate-100 py-0.5 px-1.5"
+              className="tag"
               key={i}
               onClick={() => toggleTag(tag)}
               // active={activeTags.includes(tag)}

--- a/src/components/widgets/Calendar/CalendarGrid.jsx
+++ b/src/components/widgets/Calendar/CalendarGrid.jsx
@@ -75,9 +75,10 @@ export default function CalendarGrid({ calendarData }) {
           <p>Click on the tags below to filter the workshops by topic:</p>
           {tags.map((tag, i) => (
             <button
-              className="tag"
               key={i}
               onClick={() => toggleTag(tag)}
+              className={activeTags.includes(tag) ? 'tag active': 'tag'}
+
               // active={activeTags.includes(tag)}
             >
               {tag}

--- a/src/components/widgets/Calendar/Event.jsx
+++ b/src/components/widgets/Calendar/Event.jsx
@@ -21,7 +21,7 @@ const Event = (props) => {
   const title = event[2];
   const link = event[6];
   return (
-    <div className="min-w-40 m-4 cursor-pointer basis-1/4">
+    <div className="min-w-40 cursor-pointer basis-1/5 mb-4">
       <div style={{ backgroundImage: `url(${bgImg})` }} className="bg-cover h-0 w-full flex pb-[100%] mb-4">
         {event[7] && <span>{event[7]}</span>}
       </div>
@@ -30,7 +30,7 @@ const Event = (props) => {
       {tags && (
         <div>
           {tags.map((tag) => (
-            <div className="inline-block py-0.5 px-1.5 m-1 text-sm" key={tag}>
+            <div className="tag" key={tag}>
               {tag}
             </div>
           ))}

--- a/src/components/widgets/Calendar/Event.jsx
+++ b/src/components/widgets/Calendar/Event.jsx
@@ -26,7 +26,7 @@ const Event = (props) => {
         {event[7] && <span>{event[7]}</span>}
       </div>
       {event[1]}
-      <p class="pb-2">{link ? <a href={link}>{title}</a> : <span>{title}</span>}</p>
+      <p className="pb-2">{link ? <a href={link}>{title}</a> : <span>{title}</span>}</p>
       {tags && (
         <div>
           {tags.map((tag) => (

--- a/src/components/widgets/Calendar/Event.jsx
+++ b/src/components/widgets/Calendar/Event.jsx
@@ -21,12 +21,12 @@ const Event = (props) => {
   const title = event[2];
   const link = event[6];
   return (
-    <div className="min-w-40 cursor-pointer basis-1/5 mb-4">
+    <div className="min-w-40 cursor-pointer basis-1/5 mb-4 transition ease-in-out hover:scale-95 duration-500">
       <div style={{ backgroundImage: `url(${bgImg})` }} className="bg-cover h-0 w-full flex pb-[100%] mb-4">
         {event[7] && <span>{event[7]}</span>}
       </div>
       {event[1]}
-      <h1>{link ? <a href={link}>{title}</a> : <span>{title}</span>}</h1>
+      <p class="pb-2">{link ? <a href={link}>{title}</a> : <span>{title}</span>}</p>
       {tags && (
         <div>
           {tags.map((tag) => (

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -20,7 +20,7 @@ const data = await response.json();
     <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Calendar</h1>
     <div class="flex justify-center gap-4 mt-4">
       <a
-        href="https://form.asana.com/?k=xqP6aUnpCk3PeMgTe7J1vA&d=88303944259432"
+        href="https://form.asana.com/?k=Q7C_5J_2GzFc42pZm1ketg&d=88303944259432"
         class="button rounded"
         target="_blank"
       >

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -14,8 +14,11 @@ const data = await response.json();
 <Layout metadata={{ title }}>
   <Header />
   <div class="max-w-5xl mx-auto mb-8">
-    <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Search Results</h1>
-    <div class="flex justify-center gap-4">
+    <div class="text-xs py-4 uppercase">
+      <a href="/">Home</a> / Calendar
+    </div>
+    <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Calendar</h1>
+    <div class="flex justify-center gap-4 mt-4">
       <a
         href="https://form.asana.com/?k=xqP6aUnpCk3PeMgTe7J1vA&d=88303944259432"
         class="button rounded"

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -13,7 +13,7 @@ const data = await response.json();
 
 <Layout metadata={{ title }}>
   <Header />
-  <div class="max-w-5xl mx-auto mb-8">
+  <div class="max-w-5xl mx-auto mb-8 px-8">
     <div class="text-xs py-4 uppercase">
       <a href="/">Home</a> / Calendar
     </div>

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -13,24 +13,30 @@ const data = await response.json();
 
 <Layout metadata={{ title }}>
   <Header />
-  <h1>Search Results</h1>
-  <div>
-    <a href="https://form.asana.com/?k=xqP6aUnpCk3PeMgTe7J1vA&d=88303944259432" class="button" target="_blank">
-      Submit Event
-    </a>
-    <a
-      href="https://instruction.austincc.edu/tledupdates/2019/08/20/how-to-overlap-accs-faculty-events-google-calendar-with-your-acc-google-calendar/"
-      class="button"
-      target="_blank"
-    >
-      Add Faculty Events Google Calendar
-    </a>
+  <div class="max-w-5xl mx-auto mb-8">
+    <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Search Results</h1>
+    <div class="flex justify-center gap-4">
+      <a
+        href="https://form.asana.com/?k=xqP6aUnpCk3PeMgTe7J1vA&d=88303944259432"
+        class="button rounded"
+        target="_blank"
+      >
+        Submit Event
+      </a>
+      <a
+        href="https://instruction.austincc.edu/tledupdates/2019/08/20/how-to-overlap-accs-faculty-events-google-calendar-with-your-acc-google-calendar/"
+        class="button rounded"
+        target="_blank"
+      >
+        Add Faculty Events Google Calendar
+      </a>
+    </div>
+    <CalendarGrid client:load calendarData={data} />
   </div>
-  <CalendarGrid client:load calendarData={data} />
-</Layout>
-<Footer />
 
-<!-- 
+  <Footer />
+
+  <!--
 export default SearchPage
 
 const SearchResult = styled.div`
@@ -49,3 +55,4 @@ const Query = styled.span`
   color: purple;
   font-weight: bold;
 ` -->
+</Layout>


### PR DESCRIPTION
This one should be good to go

Notes: 
- The active state on the Hashtag is now dark blue to match the reports pages and to use our standardized .tag and .tag.active classes
- The text of the hashtags is black to up the contrast as in the other .tag
- The Breadcrumbs are hard coded like all the other one off pages as our breadcrumb component doesn't work with these specialty pages