### PR TITLE
Sitemap styling

### DIFF
--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -21,7 +21,7 @@ const html = await Axios.get(sitemapData)
   <Header />
   <div class="max-w-5xl mx-auto mb-8 px-8 md:px-32">
     <div class="text-[11px] py-4 uppercase">
-      <a href="/">Home</a> / Sitemap
+      <a class="pr-2" href="/">Home</a> / <span class="pl-2">Sitemap</span>
     </div>
     <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Sitemap</h1>
     <style is:global>

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -19,8 +19,8 @@ const html = await Axios.get(sitemapData)
 
 <Layout metadata={{ title }}>
   <Header />
-  <div class="max-w-5xl mx-auto mb-8 px-8">
-    <div class="text-xs py-4 uppercase">
+  <div class="max-w-5xl mx-auto mb-8 px-8 md:px-32">
+    <div class="text-[11px] py-4 uppercase">
       <a href="/">Home</a> / Sitemap
     </div>
     <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Sitemap</h1>

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -26,7 +26,7 @@ const html = await Axios.get(sitemapData)
     <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Sitemap</h1>
     <style is:global>
       #sitemap ul {
-        margin-left: 1.1rem;
+        margin-left: 1rem;
       }
       #sitemap ul li {
         padding: 0.3rem 0;

--- a/src/pages/sitemap.astro
+++ b/src/pages/sitemap.astro
@@ -26,10 +26,10 @@ const html = await Axios.get(sitemapData)
     <h1 class="acc-bottom-border-line text-3xl font-bold uppercase">Sitemap</h1>
     <style is:global>
       #sitemap ul {
-        margin-left: 1rem;
+        margin-left: 1.1rem;
       }
       #sitemap ul li {
-        padding: 0.4rem 0;
+        padding: 0.3rem 0;
       }
       #sitemap div.menu ul {
         list-style: none;
@@ -38,15 +38,13 @@ const html = await Axios.get(sitemapData)
       #sitemap div.menu a {
         font-size: 1rem;
       }
-
       #sitemap div.menu > ul > li > a {
         font-size: 1.4rem;
+        padding: 0.6rem 0;
       }
-
       #sitemap div.menu > ul > li > ul.children > li.page_item_has_children > a {
         font-size: 1.2rem;
       }
-
       #sitemap .page-item-1365,
       #sitemap .page-item-941,
       #sitemap .page-item-943 {


### PR DESCRIPTION
Styling is complete. Letter spacing on this theme is .4px different than our current theme, so it isn't a pixel perfect recreation but that is a global style.

While fixing the breadcrumbs, I realized the other breadcrumbs on custom pages like calendar are different sizes so I have created an Asana task for me to fix those.